### PR TITLE
feat: Pull Through Cache for ECR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ aws-assumed-role/
 **/.module/
 **/.helmfile/
 
+# We pull account-map from a remote repository in Github Actions
+# However, we want to locally to validate tflint
+account-map/
 
 # Draft or auto-saved version
 # Note that the leading "**/" appears necessary for Docker even if not for Git

--- a/src/README.md
+++ b/src/README.md
@@ -58,6 +58,23 @@ components:
           stage: ["*"]
 ```
 
+### Pull Through Cache
+
+To configure a pull through cache rule, you can use the `pull_through_cache_rules` input. Each rule requires a AWS Secrets Manager secret, by name, to be provided. The secret should contain the credentials to access the registry. The `registry` field is the registry to apply the rule to and is specific to the registry. For Docker Hub, the registry is `registry-1.docker.io`.
+
+```yaml
+components:
+  terraform:
+    ecr:
+      vars:
+        enabled: true
+...
+        pull_through_cache_rules:
+          dockerhub:
+            registry: "registry-1.docker.io"
+            secret: "ecr-pullthroughcache/dockerhub"
+```
+
 <!-- prettier-ignore-start -->
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/src/README.md
+++ b/src/README.md
@@ -87,10 +87,12 @@ components:
 
 | Name | Type |
 |------|------|
+| [aws_ecr_pull_through_cache_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_pull_through_cache_rule) | resource |
 | [aws_iam_policy.ecr_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_user.ecr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy_attachment.ecr_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_policy_document.ecr_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_secretsmanager_secret.cache_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 
 ## Inputs
 
@@ -117,6 +119,7 @@ components:
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
 | <a name="input_principals_lambda"></a> [principals\_lambda](#input\_principals\_lambda) | Principal account IDs of Lambdas allowed to consume ECR | `list(string)` | `[]` | no |
 | <a name="input_protected_tags"></a> [protected\_tags](#input\_protected\_tags) | Tags to refrain from deleting | `list(string)` | `[]` | no |
+| <a name="input_pull_through_cache_rules"></a> [pull\_through\_cache\_rules](#input\_pull\_through\_cache\_rules) | Map of pull through cache rules to configure | <pre>map(object({<br/>    registry = string<br/>    secret   = optional(string, "")<br/>  }))</pre> | `{}` | no |
 | <a name="input_read_only_account_role_map"></a> [read\_only\_account\_role\_map](#input\_read\_only\_account\_role\_map) | Map of `account:[role, role...]` for read-only access. Use `*` for role to grant access to entire account | `map(list(string))` | `{}` | no |
 | <a name="input_read_write_account_role_map"></a> [read\_write\_account\_role\_map](#input\_read\_write\_account\_role\_map) | Map of `account:[role, role...]` for write access. Use `*` for role to grant access to entire account | `map(list(string))` | n/a | yes |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,3 +1,7 @@
+locals {
+  enabled = module.this.enabled
+}
+
 module "full_access" {
   source = "../account-map/modules/roles-to-principals"
 
@@ -15,7 +19,7 @@ module "readonly_access" {
 }
 
 locals {
-  ecr_user_arn = join("", aws_iam_user.ecr.*.arn)
+  ecr_user_arn = join("", aws_iam_user.ecr[*].arn)
 }
 
 module "ecr" {
@@ -34,4 +38,22 @@ module "ecr" {
   use_fullname               = false
 
   context = module.this.context
+}
+
+data "aws_secretsmanager_secret" "cache_credentials" {
+  for_each = local.enabled ? {
+    for key, rule in var.pull_through_cache_rules :
+    key => rule.secret
+    if length(rule.secret) > 0
+  } : {}
+
+  name = each.value
+}
+
+resource "aws_ecr_pull_through_cache_rule" "this" {
+  for_each = local.enabled ? var.pull_through_cache_rules : {}
+
+  ecr_repository_prefix = each.key
+  upstream_registry_url = each.value.registry
+  credential_arn        = length(each.value.secret) > 0 ? data.aws_secretsmanager_secret.cache_credentials[each.key].arn : null
 }

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -14,16 +14,16 @@ output "ecr_repo_url_map" {
 }
 
 output "ecr_user_name" {
-  value       = join("", aws_iam_user.ecr.*.name)
+  value       = join("", aws_iam_user.ecr[*].name)
   description = "ECR user name"
 }
 
 output "ecr_user_arn" {
-  value       = join("", aws_iam_user.ecr.*.arn)
+  value       = join("", aws_iam_user.ecr[*].arn)
   description = "ECR user ARN"
 }
 
 output "ecr_user_unique_id" {
-  value       = join("", aws_iam_user.ecr.*.unique_id)
+  value       = join("", aws_iam_user.ecr[*].unique_id)
   description = "ECR user unique ID assigned by AWS"
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -58,3 +58,12 @@ variable "principals_lambda" {
   description = "Principal account IDs of Lambdas allowed to consume ECR"
   default     = []
 }
+
+variable "pull_through_cache_rules" {
+  type = map(object({
+    registry = string
+    secret   = optional(string, "")
+  }))
+  description = "Map of pull through cache rules to configure"
+  default     = {}
+}


### PR DESCRIPTION
## what
- Added pull through cache
- Resolve all `tflint` failures

## why
- Pull caching is directly tied to ECR and can be included with this component
- We now require TFLint to pass

## references
- https://github.com/orgs/cloudposse/discussions/27

## Examples

Enable pull through caching with ECR as such:
1. Create an AWS Secrets Manager secret
2. Add your Pull Through Cache rules to the `ecr` component

```yaml
components:
  terraform:
    ecr:
      vars:
        enabled: true
...
        pull_through_cache_rules:
          dockerhub:
            registry: "registry-1.docker.io"
            secret: "ecr-pullthroughcache/dockerhub"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for pull-through cache rules in Amazon ECR.
  - Introduced configuration options for specifying registry credentials.

- **Improvements**
  - Updated output syntax for IAM user attributes.
  - Enhanced module flexibility with conditional resource creation.

- **Documentation**
  - Updated README with new resource and input parameter details, including examples for pull-through cache configuration.

- **Chores**
  - Added `.gitignore` entry for `account-map/` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->