### PR TITLE
add mixins, update docs

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -7,12 +7,17 @@ description: |-
   This utilizes
   [the roles-to-principals submodule](https://github.com/cloudposse/terraform-aws-components/tree/main/modules/account-map/modules/roles-to-principals)
   to assign accounts to various roles. It is also compatible with the
-  [GitHub Actions IAM Role mixin](https://github.com/cloudposse/terraform-aws-components/blob/master/mixins/github-actions-iam-role/README-github-action-iam-role.md).
+  [GitHub Actions IAM Role mixin](https://github.com/cloudposse-terraform-components/mixins/blob/main/src/mixins/github-actions-iam-role/README-github-action-iam-role.md).
+
+  <details>
+    <summary>Warning (Older) regarding <code>eks-iam</code> component </summary>
 
   > [!WARNING]
   >
   > Older versions of our reference architecture have an`eks-iam` component that needs to be updated to provide sufficient
   > IAM roles to allow pods to pull from ECR repos
+
+  </details>
 
   ## Usage
 

--- a/mixins/github-actions-iam-policy.tf
+++ b/mixins/github-actions-iam-policy.tf
@@ -1,0 +1,53 @@
+locals {
+  github_actions_iam_policy = data.aws_iam_policy_document.github_actions_iam_policy.json
+  ecr_resources_static      = [for k, v in module.ecr.repository_arn_map : v]
+  ecr_resources_wildcard    = [for k, v in module.ecr.repository_arn_map : "${v}/*"]
+  resources                 = concat(local.ecr_resources_static, local.ecr_resources_wildcard)
+}
+
+data "aws_iam_policy_document" "github_actions_iam_policy" {
+  statement {
+    sid    = "AllowECRPermissions"
+    effect = "Allow"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchDeleteImage",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:DeleteLifecyclePolicy",
+      "ecr:DescribeImages",
+      "ecr:DescribeImageScanFindings",
+      "ecr:DescribeRepositories",
+      "ecr:GetAuthorizationToken",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetLifecyclePolicy",
+      "ecr:GetLifecyclePolicyPreview",
+      "ecr:GetRepositoryPolicy",
+      "ecr:InitiateLayerUpload",
+      "ecr:ListImages",
+      "ecr:PutImage",
+      "ecr:PutImageScanningConfiguration",
+      "ecr:PutImageTagMutability",
+      "ecr:PutLifecyclePolicy",
+      "ecr:StartImageScan",
+      "ecr:StartLifecyclePolicyPreview",
+      "ecr:TagResource",
+      "ecr:UntagResource",
+      "ecr:UploadLayerPart",
+    ]
+    resources = local.resources
+  }
+
+  # required as minimum permissions for pushing and logging into a public ECR repository
+  # https://github.com/aws-actions/amazon-ecr-login#permissions
+  # https://docs.aws.amazon.com/AmazonECR/latest/public/docker-push-ecr-image.html
+  statement {
+    sid    = "AllowEcrGetAuthorizationToken"
+    effect = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "sts:GetServiceBearerToken"
+    ]
+    resources = ["*"]
+  }
+}


### PR DESCRIPTION
This pull request includes updates to documentation and the addition of a new IAM policy configuration for GitHub Actions. The changes improve compatibility, enhance security, and provide necessary permissions for ECR operations.

### Documentation Updates:
* Updated the link to the GitHub Actions IAM Role mixin in `README.yaml` to point to the correct repository. Added a collapsible warning section about updating the `eks-iam` component for older architectures to ensure sufficient IAM roles for ECR access.

### IAM Policy Enhancements:
* Added a new `github_actions_iam_policy` in `mixins/github-actions-iam-policy.tf` to define permissions for ECR operations. This includes actions like `ecr:BatchGetImage`, `ecr:PutImage`, and more, with resources dynamically fetched from the `ecr.repository_arn_map`.
* Included an additional IAM policy statement to allow the `ecr:GetAuthorizationToken` and `sts:GetServiceBearerToken` actions, ensuring the minimum permissions required for pushing and logging into public ECR repositories.