### PR TITLE
Component Refactor: Single ECR Repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+# CHANGELOG
+
+## 1.0.0
+
+### Breaking Changes
+
+- `image_names` has been removed in favor of `repository_name` - this component only supports a single repository.
+
+  ```diff
+  - image_names: [
+  -  - "cloudposse-examples/app-on-ecs"
+  -  - "cloudposse/foo"
+  -  - "cloudposse/bar"
+  - ]
+
+  + component:
+  +   ecr/repositories/app-on-ecs:
+  +     metadata:
+  +       component: ecr
+  +       inherits:
+  +         - ecr/defaults
+  +     vars:
+  +       repository_name: cloudposse-examples/app-on-ecs
+  +       name: ecr-app-on-ecs
+  ---
+  +   ecr/repositories/foo:
+  +     metadata:
+  +       component: ecr
+  +       inherits:
+  +         - ecr/defaults
+  +     vars:
+  +       repository_name: cloudposse-examples/foo
+  +       name: ecr-foo
+  ---
+  +   ecr/repositories/bar:
+  +     metadata:
+  +       component: ecr
+  +       inherits:
+  +         - ecr/defaults
+  +     vars:
+  +       repository_name: cloudposse-examples/bar
+  +       name: ecr-bar
+  ```
+
+  The Cloudposse migration for example looked like:
+
+  ```console
+  . #stacks/catalog/ecr/
+  └── repositories
+      ├── app-on-ecs.yaml
+      ├── app-on-eks-with-argocd.yaml
+      ├── defaults.yaml
+      ├── docker-component-build.yaml
+      ├── example-app-on-ecs.yaml
+      ├── example-monorepo.yaml
+      ├── infra-live.yaml
+      └── example-app-on-eks.yaml
+  ```
+
+  ```console
+  # stacks/orgs/acme/core/us-east-2/artifacts.yaml
+  imports:
+  - catalog/ecr/*
+  ```
+
+  Defaults matches the README using the default values. and each repository entry is defined in it's own catalog entry.
+
+- Lifecycle rules are now defined via the `lifecycle_rules` input.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,17 @@
 
 -->
 
-This component is responsible for provisioning repositories, lifecycle rules, and permissions for streamlined ECR usage.
+This component is responsible for provisioning an ECR repository, it's lifecycle rules, and permissions for streamlined ECR usage.
 This utilizes
 [the roles-to-principals submodule](https://github.com/cloudposse/terraform-aws-components/tree/main/modules/account-map/modules/roles-to-principals)
 to assign accounts to various roles. It is also compatible with the
 [GitHub Actions IAM Role mixin](https://github.com/cloudposse-terraform-components/mixins/blob/main/src/mixins/github-actions-iam-role/README-github-action-iam-role.md).
+
+> [!WARNING]
+> 
+> This component has had a major release and requires work to upgrade to the latest release.
+> Please see the [CHANGELOG](CHANGELOG.md) for more information.
+
 
 <details>
   <summary>Warning (Older) regarding <code>eks-iam</code> component </summary>
@@ -53,34 +59,53 @@ typically provisioned via the stack for the "artifact" account (typically `auto`
 region.
 
 ```yaml
+# catalog/ecr/defaults.yaml
 components:
   terraform:
-    ecr:
+    ecr/defaults:
       vars:
+        enabled: true
         ecr_user_enabled: false
-        enable_lifecycle_policy: true
-        max_image_count: 500
         scan_images_on_push: true
-        protected_tags:
-          - prod
-        image_tag_mutability: MUTABLE
-
-        images:
-          - infrastructure
-          - microservice-a
-          - microservice-b
-          - microservice-c
-        read_write_account_role_map:
-          identity:
-            - admin
-            - cicd
-          automation:
-            - admin
+        # github_actions_iam_role_enabled: true
+        # github_actions_iam_role_attributes: [ "ecr" ]
+        # github_actions_allowed_repos:
+        #   - ACME_ORG/acme-repo
+        #   - ACME_ORG/*
         read_only_account_role_map:
-          corp: ["*"]
-          dev: ["*"]
-          prod: ["*"]
-          stage: ["*"]
+          plat-dev: ["*"]
+          plat-sandbox: ["*"]
+          plat-staging: ["*"]
+          plat-prod: ["*"]
+        read_write_account_role_map:
+          core-identity:
+            - devops
+            - developers
+          core-auto:
+            - admin
+            - poweruser
+```
+Instances of the component can then be created via
+```yaml
+# catalog/ecr/app-on-ecs.yaml
+imports:
+  - catalog/ecr/defaults
+components:
+  terraform:
+    ecr/repositories/app-on-ecs:
+      metadata:
+        component: ecr
+        inherits:
+          - ecr/defaults
+      vars:
+        repository_name: ACME_ORG/app-on-ecs
+        name: ecr-app-on-ecs
+```
+You can then import multiple catalog ECR entries via
+```yaml
+# orgs/acme/core/us-east-2/artifacts.yaml
+imports:
+  - catalog/ecr/*
 ```
 
 <!-- prettier-ignore-start -->
@@ -90,19 +115,19 @@ components:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0, < 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0, < 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ecr"></a> [ecr](#module\_ecr) | cloudposse/ecr/aws | 0.42.1 |
+| <a name="module_ecr"></a> [ecr](#module\_ecr) | cloudposse/ecr/aws | 0.36.0 |
 | <a name="module_full_access"></a> [full\_access](#module\_full\_access) | ../account-map/modules/roles-to-principals | n/a |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_readonly_access"></a> [readonly\_access](#module\_readonly\_access) | ../account-map/modules/roles-to-principals | n/a |
@@ -112,47 +137,43 @@ components:
 
 | Name | Type |
 |------|------|
-| [aws_ecr_pull_through_cache_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_pull_through_cache_rule) | resource |
 | [aws_iam_policy.ecr_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_user.ecr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy_attachment.ecr_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_policy_document.ecr_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_secretsmanager_secret.cache_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
-| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
-| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>  format = string<br/>  labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_ecr_user_enabled"></a> [ecr\_user\_enabled](#input\_ecr\_user\_enabled) | Enable/disable the provisioning of the ECR user (for CI/CD systems that don't support assuming IAM roles to access ECR, e.g. Codefresh) | `bool` | `false` | no |
 | <a name="input_enable_lifecycle_policy"></a> [enable\_lifecycle\_policy](#input\_enable\_lifecycle\_policy) | Enable/disable image lifecycle policy | `bool` | n/a | yes |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_image_tag_mutability"></a> [image\_tag\_mutability](#input\_image\_tag\_mutability) | The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE` | `string` | `"MUTABLE"` | no |
 | <a name="input_images"></a> [images](#input\_images) | List of image names (ECR repo names) to create repos for | `list(string)` | n/a | yes |
-| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
-| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
-| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
-| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
 | <a name="input_max_image_count"></a> [max\_image\_count](#input\_max\_image\_count) | Max number of images to store. Old ones will be deleted to make room for new ones. | `number` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
 | <a name="input_principals_lambda"></a> [principals\_lambda](#input\_principals\_lambda) | Principal account IDs of Lambdas allowed to consume ECR | `list(string)` | `[]` | no |
 | <a name="input_protected_tags"></a> [protected\_tags](#input\_protected\_tags) | Tags to refrain from deleting | `list(string)` | `[]` | no |
-| <a name="input_pull_through_cache_rules"></a> [pull\_through\_cache\_rules](#input\_pull\_through\_cache\_rules) | Map of pull through cache rules to configure | <pre>map(object({<br/>    registry = string<br/>    secret   = optional(string, "")<br/>  }))</pre> | `{}` | no |
 | <a name="input_read_only_account_role_map"></a> [read\_only\_account\_role\_map](#input\_read\_only\_account\_role\_map) | Map of `account:[role, role...]` for read-only access. Use `*` for role to grant access to entire account | `map(list(string))` | `{}` | no |
 | <a name="input_read_write_account_role_map"></a> [read\_write\_account\_role\_map](#input\_read\_write\_account\_role\_map) | Map of `account:[role, role...]` for write access. Use `*` for role to grant access to entire account | `map(list(string))` | n/a | yes |
-| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
-| <a name="input_replication_configurations"></a> [replication\_configurations](#input\_replication\_configurations) | Replication configuration for a registry. See [Replication Configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_replication_configuration#replication-configuration). | <pre>list(object({<br/>    rules = list(object({<br/>      destinations = list(object({<br/>        region      = string<br/>        registry_id = string<br/>      }))<br/>      repository_filters = list(object({<br/>        filter      = string<br/>        filter_type = string<br/>      }))<br/>    }))<br/>  }))</pre> | `[]` | no |
 | <a name="input_scan_images_on_push"></a> [scan\_images\_on\_push](#input\_scan\_images\_on\_push) | Indicates whether images are scanned after being pushed to the repository | `bool` | `false` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
 
 ## Outputs
@@ -189,7 +210,7 @@ components:
 > <summary><strong>Watch demo of using Atmos with Terraform</strong></summary>
 > <img src="https://github.com/cloudposse/atmos/blob/main/docs/demo.gif?raw=true"/><br/>
 > <i>Example of running <a href="https://atmos.tools"><code>atmos</code></a> to manage infrastructure from our <a href="https://atmos.tools/quick-start/">Quick Start</a> tutorial.</i>
-> </details>
+> </detalis>
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -3,11 +3,17 @@ name: "aws-ecr"
 github_repo: "cloudposse-terraform-components/aws-ecr"
 # Short description of this project
 description: |-
-  This component is responsible for provisioning repositories, lifecycle rules, and permissions for streamlined ECR usage.
+  This component is responsible for provisioning an ECR repository, it's lifecycle rules, and permissions for streamlined ECR usage.
   This utilizes
   [the roles-to-principals submodule](https://github.com/cloudposse/terraform-aws-components/tree/main/modules/account-map/modules/roles-to-principals)
   to assign accounts to various roles. It is also compatible with the
   [GitHub Actions IAM Role mixin](https://github.com/cloudposse-terraform-components/mixins/blob/main/src/mixins/github-actions-iam-role/README-github-action-iam-role.md).
+
+  > [!WARNING]
+  > 
+  > This component has had a major release and requires work to upgrade to the latest release.
+  > Please see the [CHANGELOG](CHANGELOG.md) for more information.
+
 
   <details>
     <summary>Warning (Older) regarding <code>eks-iam</code> component </summary>
@@ -29,34 +35,53 @@ description: |-
   region.
 
   ```yaml
+  # catalog/ecr/defaults.yaml
   components:
     terraform:
-      ecr:
+      ecr/defaults:
         vars:
+          enabled: true
           ecr_user_enabled: false
-          enable_lifecycle_policy: true
-          max_image_count: 500
           scan_images_on_push: true
-          protected_tags:
-            - prod
-          image_tag_mutability: MUTABLE
-
-          images:
-            - infrastructure
-            - microservice-a
-            - microservice-b
-            - microservice-c
-          read_write_account_role_map:
-            identity:
-              - admin
-              - cicd
-            automation:
-              - admin
+          # github_actions_iam_role_enabled: true
+          # github_actions_iam_role_attributes: [ "ecr" ]
+          # github_actions_allowed_repos:
+          #   - ACME_ORG/acme-repo
+          #   - ACME_ORG/*
           read_only_account_role_map:
-            corp: ["*"]
-            dev: ["*"]
-            prod: ["*"]
-            stage: ["*"]
+            plat-dev: ["*"]
+            plat-sandbox: ["*"]
+            plat-staging: ["*"]
+            plat-prod: ["*"]
+          read_write_account_role_map:
+            core-identity:
+              - devops
+              - developers
+            core-auto:
+              - admin
+              - poweruser
+  ```
+  Instances of the component can then be created via
+  ```yaml
+  # catalog/ecr/app-on-ecs.yaml
+  imports:
+    - catalog/ecr/defaults
+  components:
+    terraform:
+      ecr/repositories/app-on-ecs:
+        metadata:
+          component: ecr
+          inherits:
+            - ecr/defaults
+        vars:
+          repository_name: ACME_ORG/app-on-ecs
+          name: ecr-app-on-ecs
+  ```
+  You can then import multiple catalog ECR entries via
+  ```yaml
+  # orgs/acme/core/us-east-2/artifacts.yaml
+  imports:
+    - catalog/ecr/*
   ```
 
   <!-- prettier-ignore-start -->

--- a/mixins/github-actions-iam-policy.tf
+++ b/mixins/github-actions-iam-policy.tf
@@ -1,7 +1,7 @@
 locals {
   github_actions_iam_policy = data.aws_iam_policy_document.github_actions_iam_policy.json
-  ecr_resources_static      = [for k, v in module.ecr.repository_arn_map : v]
-  ecr_resources_wildcard    = [for k, v in module.ecr.repository_arn_map : "${v}/*"]
+  ecr_resources_static      = [module.ecr.repository_arn]
+  ecr_resources_wildcard    = ["${module.ecr.repository_arn}/*"]
   resources                 = concat(local.ecr_resources_static, local.ecr_resources_wildcard)
 }
 

--- a/mixins/imports.tf
+++ b/mixins/imports.tf
@@ -1,0 +1,18 @@
+/**
+We don't include this in the source component, because it requires a specific version of terraform or tofu we'd rather not dictate, this is a nice utility to have
+*/
+
+variable "imports" {
+  type = object({
+    repository = bool
+  })
+  default = {
+    repository = false
+  }
+}
+
+import {
+  for_each = var.imports.repository ? toset([var.repository_name]) : toset([])
+  to       = module.ecr.aws_ecr_repository.this[0]
+  id       = var.repository_name
+}

--- a/src/README.md
+++ b/src/README.md
@@ -30,32 +30,28 @@ region.
 ```yaml
 components:
   terraform:
-    ecr:
+    ecr/defaults:
       vars:
+        enabled: true
         ecr_user_enabled: false
-        enable_lifecycle_policy: true
-        max_image_count: 500
         scan_images_on_push: true
-        protected_tags:
-          - prod
-        image_tag_mutability: MUTABLE
-
-        images:
-          - infrastructure
-          - microservice-a
-          - microservice-b
-          - microservice-c
-        read_write_account_role_map:
-          identity:
-            - admin
-            - cicd
-          automation:
-            - admin
+        github_actions_iam_role_enabled: true
+        github_actions_iam_role_attributes: ["ecr"]
+        github_actions_allowed_repos:
+          - ACME_ORG/acme-repo
+          - ACME_ORG/*
         read_only_account_role_map:
-          corp: ["*"]
-          dev: ["*"]
-          prod: ["*"]
-          stage: ["*"]
+          plat-dev: ["*"]
+          plat-sandbox: ["*"]
+          plat-staging: ["*"]
+          plat-prod: ["*"]
+        read_write_account_role_map:
+          core-identity:
+            - devops
+            - developers
+          core-auto:
+            - admin
+            - poweruser
 ```
 
 ### Pull Through Cache
@@ -68,11 +64,11 @@ components:
     ecr:
       vars:
         enabled: true
-...
-        pull_through_cache_rules:
-          dockerhub:
-            registry: "registry-1.docker.io"
-            secret: "ecr-pullthroughcache/dockerhub"
+---
+pull_through_cache_rules:
+  dockerhub:
+    registry: "registry-1.docker.io"
+    secret: "ecr-pullthroughcache/dockerhub"
 ```
 
 <!-- prettier-ignore-start -->
@@ -82,19 +78,19 @@ components:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0, < 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0, < 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ecr"></a> [ecr](#module\_ecr) | cloudposse/ecr/aws | 0.42.1 |
+| <a name="module_ecr"></a> [ecr](#module\_ecr) | cloudposse/ecr/aws | 0.41.0 |
 | <a name="module_full_access"></a> [full\_access](#module\_full\_access) | ../account-map/modules/roles-to-principals | n/a |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_readonly_access"></a> [readonly\_access](#module\_readonly\_access) | ../account-map/modules/roles-to-principals | n/a |

--- a/src/main.tf
+++ b/src/main.tf
@@ -23,20 +23,20 @@ locals {
 }
 
 module "ecr" {
-  source  = "cloudposse/ecr/aws"
-  version = "0.42.1"
 
-  protected_tags             = var.protected_tags
-  enable_lifecycle_policy    = var.enable_lifecycle_policy
-  image_names                = var.images
-  image_tag_mutability       = var.image_tag_mutability
-  max_image_count            = var.max_image_count
+  source  = "cloudposse/ecr/aws"
+  version = "1.0.0"
+
+  repository_name = var.repository_name
+
   principals_full_access     = compact(concat(module.full_access.principals, [local.ecr_user_arn]))
   principals_readonly_access = module.readonly_access.principals
   principals_lambda          = var.principals_lambda
   scan_images_on_push        = var.scan_images_on_push
-  use_fullname               = false
+  force_delete               = var.force_delete
+
   replication_configurations = var.replication_configurations
+  lifecycle_rules            = var.lifecycle_rules
 
   context = module.this.context
 }

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -1,29 +1,34 @@
-output "ecr_repo_arn_map" {
-  value       = module.ecr.repository_arn_map
-  description = "Map of image names to ARNs"
+output "registry_id" {
+  value       = one(module.ecr[*].registry_id)
+  description = "Registry ID"
 }
 
-output "repository_host" {
-  value       = try(split("/", module.ecr.repository_url)[0], null)
-  description = "ECR repository name"
+output "repository_name" {
+  value       = one(module.ecr[*].repository_name)
+  description = "Name of first repository created"
 }
 
-output "ecr_repo_url_map" {
-  value       = module.ecr.repository_url_map
-  description = "Map of image names to URLs"
+output "repository_url" {
+  value       = one(module.ecr[*].repository_url)
+  description = "URL of first repository created"
+}
+
+output "repository_arn" {
+  value       = one(module.ecr[*].repository_arn)
+  description = "ARN of first repository created"
 }
 
 output "ecr_user_name" {
-  value       = join("", aws_iam_user.ecr[*].name)
+  value       = one(aws_iam_user.ecr[*].name)
   description = "ECR user name"
 }
 
 output "ecr_user_arn" {
-  value       = join("", aws_iam_user.ecr[*].arn)
+  value       = one(aws_iam_user.ecr[*].arn)
   description = "ECR user ARN"
 }
 
 output "ecr_user_unique_id" {
-  value       = join("", aws_iam_user.ecr[*].unique_id)
+  value       = one(aws_iam_user.ecr[*].unique_id)
   description = "ECR user unique ID assigned by AWS"
 }

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0, < 6.0.0"
+      version = ">= 4.9.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Goes together with https://github.com/cloudposse/terraform-aws-ecr/pull/147
* Removes "Factory" of ECR Repositories
* Adds better support for lifecycle policies

## why
* ECR Factory should now be defined in stacks.
 
---

The major purpose of this Pull Request is to move the "heavy lifting" of managing ECR Repositories from this one component and module to atmos stacks

## what
 - Removes for_each of image_name that creates several ECR Repositories.
 - Removes "built in" ECR Lifecycle Policies
 - Removes outputs that previosuly declared the entire ECR Map.

## why
 This is an initially controversial change. We are removing some of the "Batteries included" in our module, in exchange we are improving the flexibility of it. I initially was not in favor of this change so let me now try to convince you as I was.
 
### Questions
 > Our Component currently outputs the entire ARN map of all ECR Repositories which is useful for other components to look up and add to IAM Permissions.

Turns out, the only thing looking up ECR Repository ARNs is the attached GitHub role that allows pushing to the ECR. If we want to create a role that can push to any ECR, there's a data source to look up all repositories, and it's not that hard to recreate.Having this module handle individual repositories also allows our component to then create specific roles for GitHub Actions to assume to be able to push to individual repositories. This allows much finer-grained controls and tighter permissions. And of course, there's always a wild card option if you want to go back.

> How is this more flexible?

This is more flexible because our component in this module can now create custom lifecycle policies and custom rules per individual repositories.

> Isn't this less dry?


There are two thoughts to this. 

One is, if you're using atmos, you can simply create stacks. These stacks can be repeated either using templating or with inheritance to become very dry themselves. Creating stack configurations—a snippet of YAML—is very easy and fast, and oftentimes it's a 1-up or CI is going to handle reapplying it frequently.

Since stacks are so easy to create, this allows us to still be very dry and not need to apply terraform components that affect many resources.

The second is, if you're not using atmos and you're just using this module, you can always surround it in a foreach—and that's not that hard. 

