### PR TITLE
Update Submodule and support `custom_lifcycle_rules`

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -23,8 +23,8 @@ locals {
 }
 
 module "ecr" {
-  source = "cloudposse/ecr/aws"
-  # version = "0.42.2" #TODO
+  source  = "cloudposse/ecr/aws"
+  version = "0.43.0"
 
   protected_tags             = var.protected_tags
   enable_lifecycle_policy    = var.enable_lifecycle_policy

--- a/src/main.tf
+++ b/src/main.tf
@@ -27,6 +27,7 @@ module "ecr" {
   version = "0.43.0"
 
   protected_tags             = var.protected_tags
+  protected_tags_keep_count  = var.protected_tags_keep_count
   enable_lifecycle_policy    = var.enable_lifecycle_policy
   image_names                = var.images
   image_tag_mutability       = var.image_tag_mutability

--- a/src/main.tf
+++ b/src/main.tf
@@ -24,20 +24,21 @@ locals {
 
 module "ecr" {
   source  = "cloudposse/ecr/aws"
-  version = "0.43.0"
+  version = "0.44.0"
 
-  protected_tags             = var.protected_tags
-  protected_tags_keep_count  = var.protected_tags_keep_count
-  enable_lifecycle_policy    = var.enable_lifecycle_policy
-  image_names                = var.images
-  image_tag_mutability       = var.image_tag_mutability
-  max_image_count            = var.max_image_count
-  principals_full_access     = compact(concat(module.full_access.principals, [local.ecr_user_arn]))
-  principals_readonly_access = module.readonly_access.principals
-  principals_lambda          = var.principals_lambda
-  scan_images_on_push        = var.scan_images_on_push
-  use_fullname               = false
-  replication_configurations = var.replication_configurations
+  protected_tags                   = var.protected_tags
+  protected_tags_keep_count        = var.protected_tags_keep_count
+  enable_lifecycle_policy          = var.enable_lifecycle_policy
+  default_lifecycle_rules_settings = var.default_lifecycle_rules_settings
+  image_names                      = var.images
+  image_tag_mutability             = var.image_tag_mutability
+  max_image_count                  = var.max_image_count
+  principals_full_access           = compact(concat(module.full_access.principals, [local.ecr_user_arn]))
+  principals_readonly_access       = module.readonly_access.principals
+  principals_lambda                = var.principals_lambda
+  scan_images_on_push              = var.scan_images_on_push
+  use_fullname                     = false
+  replication_configurations       = var.replication_configurations
 
   custom_lifecycle_rules = var.custom_lifecycle_rules
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -23,8 +23,8 @@ locals {
 }
 
 module "ecr" {
-  source  = "cloudposse/ecr/aws"
-  version = "0.42.2"
+  source = "cloudposse/ecr/aws"
+  # version = "0.42.2" #TODO
 
   protected_tags             = var.protected_tags
   enable_lifecycle_policy    = var.enable_lifecycle_policy
@@ -37,6 +37,8 @@ module "ecr" {
   scan_images_on_push        = var.scan_images_on_push
   use_fullname               = false
   replication_configurations = var.replication_configurations
+
+  custom_lifecycle_rules = var.custom_lifecycle_rules
 
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -84,3 +84,60 @@ variable "replication_configurations" {
   description = "Replication configuration for a registry. See [Replication Configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_replication_configuration#replication-configuration)."
   default     = []
 }
+
+variable "custom_lifecycle_rules" {
+  description = "Custom lifecycle rules to override or complement the default ones"
+  type = list(object({
+    description = optional(string)
+    selection = object({
+      tagStatus      = string
+      countType      = string
+      countNumber    = number
+      countUnit      = optional(string)
+      tagPrefixList  = optional(list(string))
+      tagPatternList = optional(list(string))
+    })
+    action = object({
+      type = string
+    })
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for rule in var.custom_lifecycle_rules :
+      rule.selection.tagStatus != "tagged" || (length(coalesce(rule.selection.tagPrefixList, [])) > 0 || length(coalesce(rule.selection.tagPatternList, [])) > 0)
+    ])
+    error_message = "if tagStatus is tagged - specify tagPrefixList or tagPatternList"
+  }
+  validation {
+    condition = alltrue([
+      for rule in var.custom_lifecycle_rules :
+      rule.selection.countNumber > 0
+    ])
+    error_message = "Count number should be > 0"
+  }
+
+  validation {
+    condition = alltrue([
+      for rule in var.custom_lifecycle_rules :
+      contains(["tagged", "untagged", "any"], rule.selection.tagStatus)
+    ])
+    error_message = "Valid values for tagStatus are: tagged, untagged, or any."
+  }
+  validation {
+    condition = alltrue([
+      for rule in var.custom_lifecycle_rules :
+      contains(["imageCountMoreThan", "sinceImagePushed"], rule.selection.countType)
+    ])
+    error_message = "Valid values for countType are: imageCountMoreThan or sinceImagePushed."
+  }
+
+  validation {
+    condition = alltrue([
+      for rule in var.custom_lifecycle_rules :
+      rule.selection.countType != "sinceImagePushed" || rule.selection.countUnit != null
+    ])
+    error_message = "For countType = 'sinceImagePushed', countUnit must be specified."
+  }
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -48,6 +48,12 @@ variable "protected_tags" {
   default     = []
 }
 
+variable "protected_tags_keep_count" {
+  type        = number
+  description = "Number of Image versions to keep for protected tags"
+  default     = 999999
+}
+
 variable "enable_lifecycle_policy" {
   type        = bool
   description = "Enable/disable image lifecycle policy"

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -149,6 +149,7 @@ variable "custom_lifecycle_rules" {
 }
 
 variable "default_lifecycle_rules_settings" {
+  description = "Default lifecycle rules settings"
   type = object({
     untagged_image_rule = optional(object({
       enabled = optional(bool, true)

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -147,3 +147,26 @@ variable "custom_lifecycle_rules" {
     error_message = "For countType = 'sinceImagePushed', countUnit must be specified."
   }
 }
+
+variable "default_lifecycle_rules_settings" {
+  type = object({
+    untagged_image_rule = optional(object({
+      enabled = optional(bool, true)
+      }), {
+      enabled = true
+    })
+    remove_old_image_rule = optional(object({
+      enabled = optional(bool, true)
+      }), {
+      enabled = true
+    })
+  })
+  default = {
+    untagged_image_rule = {
+      enabled = true
+    }
+    remove_old_image_rule = {
+      enabled = true
+    }
+  }
+}


### PR DESCRIPTION
This pull request updates the `ecr` module version and introduces support for custom lifecycle rules in the Terraform configuration. The most important changes include enhancements to lifecycle policy customization and validation logic for the new variable.

### Module Updates:
* [`src/main.tf`](diffhunk://#diff-1956abf05e8db0150fc12428093f137d1e9cca0a1d2d780a890c054274fb1e30L27-R27): Updated the `ecr` module version from `0.42.2` to `0.43.0` to incorporate new features and improvements.

### Lifecycle Policy Customization:
* [`src/main.tf`](diffhunk://#diff-1956abf05e8db0150fc12428093f137d1e9cca0a1d2d780a890c054274fb1e30R41-R42): Added support for `custom_lifecycle_rules` in the `ecr` module, enabling users to define custom rules for managing ECR image lifecycle.
* [`src/variables.tf`](diffhunk://#diff-e64d396480ef61e94c68b45e4940f63bdb28cce844c90404d648122910254904R87-R143): Introduced a new variable `custom_lifecycle_rules`, allowing detailed configuration of lifecycle rules, including validation to ensure proper rule definitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom lifecycle rules for image repositories, allowing more flexible management of image retention policies.
  * Introduced a setting to specify the number of image versions to retain for protected tags.
  * Enabled default lifecycle rule settings for untagged images and removal of old images.

* **Chores**
  * Updated the ECR Terraform module to version 0.44.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->